### PR TITLE
Clamp trail length limits

### DIFF
--- a/tests/test_trail_length.py
+++ b/tests/test_trail_length.py
@@ -1,0 +1,29 @@
+import pytest
+from threebody import constants as C
+from threebody.rendering import Body
+
+
+def test_init_clamps_trail_length_low():
+    b = Body(1.0, 0, 0, 0, 0, (255,255,255), 5, max_trail_length=C.MIN_TRAIL_LENGTH-10)
+    assert b.max_trail_length == C.MIN_TRAIL_LENGTH
+    assert b.trail.maxlen == C.MIN_TRAIL_LENGTH
+
+
+def test_init_clamps_trail_length_high():
+    b = Body(1.0, 0, 0, 0, 0, (255,255,255), 5, max_trail_length=C.MAX_TRAIL_LENGTH+10)
+    assert b.max_trail_length == C.MAX_TRAIL_LENGTH
+    assert b.trail.maxlen == C.MAX_TRAIL_LENGTH
+
+
+def test_set_trail_length_clamps_low():
+    b = Body(1.0, 0, 0, 0, 0, (255,255,255), 5)
+    b.set_trail_length(C.MIN_TRAIL_LENGTH-20)
+    assert b.max_trail_length == C.MIN_TRAIL_LENGTH
+    assert b.trail.maxlen == C.MIN_TRAIL_LENGTH
+
+
+def test_set_trail_length_clamps_high():
+    b = Body(1.0, 0, 0, 0, 0, (255,255,255), 5)
+    b.set_trail_length(C.MAX_TRAIL_LENGTH+20)
+    assert b.max_trail_length == C.MAX_TRAIL_LENGTH
+    assert b.trail.maxlen == C.MAX_TRAIL_LENGTH

--- a/threebody/rendering.py
+++ b/threebody/rendering.py
@@ -20,7 +20,9 @@ class Body:
         self.color = color
         self.radius_pixels = max(1, int(radius))
         self.show_trail = show_trail
-        self.max_trail_length = int(max_trail_length)
+        clamped_length = max(C.MIN_TRAIL_LENGTH,
+                             min(C.MAX_TRAIL_LENGTH, int(max_trail_length)))
+        self.max_trail_length = clamped_length
         self.trail = deque(maxlen=self.max_trail_length)
         self.visible = True
         self.id = Body.ID_counter
@@ -46,8 +48,13 @@ class Body:
         self.trail.clear()
 
     def set_trail_length(self, length):
-        """Update maximum trail length and keep existing points."""
-        self.max_trail_length = max(1, int(length))
+        """Update maximum trail length within allowed limits and keep existing points.
+
+        ``length`` is clamped to the range ``[C.MIN_TRAIL_LENGTH, C.MAX_TRAIL_LENGTH]``.
+        """
+        clamped_length = max(C.MIN_TRAIL_LENGTH,
+                             min(C.MAX_TRAIL_LENGTH, int(length)))
+        self.max_trail_length = clamped_length
         self.trail = deque(self.trail, maxlen=self.max_trail_length)
 
     def draw(self, screen, zoom, pan_offset, draw_labels):


### PR DESCRIPTION
## Summary
- clamp `max_trail_length` during `Body` construction
- clamp value in `Body.set_trail_length`
- document limits in the setter docstring
- test trail length clamping

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684311b84cac8327a6e2f293ffe23865