### PR TITLE
Fix README formatting and explain trail length

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ from threebody import Body, perform_rk4_step, system_energy
 
 ## Adjusting Body Trails
 
-
+Use `Body.set_trail_length(length)` to change how many trail points a body
+retains. The length is clamped between `MIN_TRAIL_LENGTH` and
+`MAX_TRAIL_LENGTH` from `threebody.constants`. Newly created bodies use
+`DEFAULT_TRAIL_LENGTH` as the initial value.
 
 ## Collision Behaviour
 
@@ -41,8 +44,6 @@ Install the dependencies and run unit tests with:
 ```bash
 pip install -r requirements.txt
 PYTHONPATH=. pytest -q
-```
-
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- fix README trailing code fence
- document how to set body trail length and mention constants

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684318cbc5d883279104082c591aead2