### PR TITLE
Clarify Body classes and add representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The package also exposes physics helpers that can be imported from Python:
 from threebody import Body, perform_rk4_step, system_energy
 ```
 
+The interactive simulation itself relies on the richer `Body` class defined in
+`threebody.rendering`, which includes drawing and trail management.
+
 ## Adjusting Body Trails
 
 

--- a/threebody/physics.py
+++ b/threebody/physics.py
@@ -1,4 +1,9 @@
-"""Minimal physics utilities for N-body simulations."""
+"""Minimal physics utilities for N-body simulations.
+
+This module defines a lightweight :class:`Body` class intended purely for
+physics calculations and unit tests.  The pygame-based simulation uses the
+more feature rich :class:`~threebody.rendering.Body` instead.
+"""
 import numpy as np
 
 # Physical constants
@@ -8,12 +13,18 @@ SOFTENING_FACTOR_SQ = 1.0**2  # m^2 softening
 
 
 class Body:
-    """Simple body representation."""
+    """Simple body representation for physics computations."""
     def __init__(self, mass, pos, vel, fixed=False):
         self.mass = float(mass)
         self.pos = np.asarray(pos, dtype=float)
         self.vel = np.asarray(vel, dtype=float)
         self.fixed = fixed
+
+    def __repr__(self):
+        return (
+            f"Body(mass={self.mass}, pos={self.pos.tolist()}, "
+            f"vel={self.vel.tolist()}, fixed={self.fixed})"
+        )
 
 
 def accelerations(bodies, g_constant=G_REAL):

--- a/threebody/rendering.py
+++ b/threebody/rendering.py
@@ -1,4 +1,9 @@
-"""Rendering helpers and Body class."""
+"""Rendering helpers and Body class.
+
+The :class:`Body` defined here is used by the interactive pygame simulation.  It
+extends the simpler physics body with additional visual properties such as
+color, radius and trail management.
+"""
 from collections import deque
 import pygame
 import pygame.gfxdraw
@@ -28,6 +33,12 @@ class Body:
         Body.ID_counter += 1
         self.name = name if name else f"Body {self.id}"
         self.last_screen_pos = np.zeros(2)
+
+    def __repr__(self):
+        return (
+            f"Body(mass={self.mass}, pos={self.pos.tolist()}, "
+            f"vel={self.vel.tolist()}, fixed={self.fixed})"
+        )
 
     def update_physics_state(self, new_pos_sim, new_vel_m_s):
         if not self.fixed:


### PR DESCRIPTION
## Summary
- add note to README about the simulation using the rendering Body
- document the intent of each Body class in their modules
- implement informative `__repr__` methods for both Body classes

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684318c7fa5c8327bebacec37b1b51e2