### PR TITLE
Clarify test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,27 @@ elastic collision model.
 
 ## Tests and Linting
 
-Install the dependencies and run unit tests with:
+Install the dependencies first. These are heavy packages and may take a while to
+download and compile:
 
 ```bash
 pip install -r requirements.txt
-PYTHONPATH=. pytest -q
 ```
 
-```
+Run the tests using one of the following options:
+
+1. Without installing the package:
+
+   ```bash
+   PYTHONPATH=. pytest -q
+   ```
+
+2. Install in editable mode first:
+
+   ```bash
+   pip install -e .
+   pytest -q
+   ```
 
 ## License
 


### PR DESCRIPTION
## Summary
- update README tests section with two ways to run tests
- note that installing dependencies can take time

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684318c7309c8327bd0e79eee8f8d379