### PR TITLE
Add collision bounce and JIT boundary tests

### DIFF
--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -19,3 +19,13 @@ def test_collision_merge_on_true():
     removed = detect_and_handle_collisions(bodies, merge_on_collision=True)
     assert removed == [1]
     assert np.isclose(b1.mass, 3 * C.EARTH_MASS)
+
+
+def test_collision_bounce_when_merge_false():
+    b1 = Body(C.EARTH_MASS, -0.0005, 0, 1.0, 0.0, C.WHITE, 5, name="A")
+    b2 = Body(C.EARTH_MASS, 0.0005, 0, -1.0, 0.0, C.WHITE, 5, name="B")
+    bodies = [b1, b2]
+    removed = detect_and_handle_collisions(bodies, merge_on_collision=False)
+    assert removed == []
+    assert np.isclose(b1.vel[0], -0.7)
+    assert np.isclose(b2.vel[0], 0.7)

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -1,0 +1,20 @@
+import numpy as np
+from threebody.jit import apply_boundary_conditions_jit
+
+
+def test_apply_boundary_conditions_jit_reflects():
+    pos = np.array([1.2, 0.5])
+    vel = np.array([1.0, 0.0])
+    bounds = (0.0, 0.0, 1.0, 1.0)
+    new_pos, new_vel = apply_boundary_conditions_jit(pos, vel, bounds, 0.5)
+    assert np.allclose(new_pos, [0.9, 0.5])
+    assert np.allclose(new_vel, [-0.5, 0.0])
+
+
+def test_apply_boundary_conditions_jit_no_change():
+    pos = np.array([0.5, 0.5])
+    vel = np.array([0.1, -0.2])
+    bounds = (0.0, 0.0, 1.0, 1.0)
+    new_pos, new_vel = apply_boundary_conditions_jit(pos, vel, bounds, 0.8)
+    assert np.allclose(new_pos, pos)
+    assert np.allclose(new_vel, vel)

--- a/threebody/jit.py
+++ b/threebody/jit.py
@@ -9,7 +9,10 @@ except ImportError:  # pragma: no cover - numba optional
     def nb_njit(func):
         return func
 
-    nb = type("obj", (object,), {"njit": nb_njit})()
+    class DummyNB:
+        njit = staticmethod(nb_njit)
+
+    nb = DummyNB()
     NUMBA_AVAILABLE = False
 
 


### PR DESCRIPTION
## Summary
- test bouncing behavior when `MERGE_ON_COLLISION` is `False`
- add unit tests for `apply_boundary_conditions_jit`
- make numba fallback usable when numba isn't installed

## Testing
- `PYTHONPATH=. pytest -q`
- `pip uninstall -y numba`
- `PYTHONPATH=. pytest -q`
- `pip install numba`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433586a2a48327a833fe06411b7366