### PR TITLE
Improve numba fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Install the package and its required dependencies:
 pip install .
 ```
 
+Numba is used for optional JIT acceleration. If it is missing or fails to
+initialize, the simulation automatically falls back to pure Python code so all
+features remain available.
+
 ## Running the Simulation
 
 Start the interactive application with:

--- a/threebody/jit.py
+++ b/threebody/jit.py
@@ -1,11 +1,16 @@
-"""JIT accelerated helpers using numba when available."""
+"""JIT accelerated helpers using numba when available.
+
+If numba fails to import or initialize for any reason, these helpers fall back
+to pure Python implementations so the package continues to work without JIT
+acceleration.
+"""
 
 import numpy as np
 
 try:
     import numba as nb
     NUMBA_AVAILABLE = True
-except ImportError:  # pragma: no cover - numba optional
+except Exception:  # pragma: no cover - numba optional or misconfigured
     def nb_njit(func):
         return func
 


### PR DESCRIPTION
## Summary
- catch all exceptions during numba import so jit remains optional
- document automatic disable of JIT when numba fails

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684335844dd08327ae4afc2fa75484d9