### PR TITLE
Fix pygame dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,6 @@ dependencies = [
     "numpy",
     "matplotlib",
     "numba",
-    "pygame",
+    "pygame-ce>=2.5.4",
     "pygame_gui",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 matplotlib
 numba
-pygame
+pygame-ce>=2.5.4
 pygame_gui


### PR DESCRIPTION
## Summary
- use `pygame-ce` instead of `pygame` for compatibility with `pygame_gui`

## Testing
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q`
- `python -m threebody.simulation_full` *(fails to open display but starts without import errors)*

------
https://chatgpt.com/codex/tasks/task_e_684337e1c27c8327bd06934fd8dced66