### PR TITLE
Fix acceleration sum in numba jit

### DIFF
--- a/threebody/jit.py
+++ b/threebody/jit.py
@@ -35,7 +35,7 @@ def calculate_acceleration_jit(target_pos_sim, target_mass_kg, other_positions_s
         acc_mag = g_const * other_masses_kg[i] / (dist_sq_meters + softening_sq_m2)
         dist_sim = np.sqrt(dist_sq_sim)
         direction_vec = distance_vec_sim / dist_sim
-    acc += direction_vec * acc_mag
+        acc += direction_vec * acc_mag
     return acc
 
 


### PR DESCRIPTION
## Summary
- ensure each iteration adds to acceleration sum in `calculate_acceleration_jit`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433c060bb883278b476ce712c334f9