### PR TITLE
Update installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ Python scripts.
 
 ## Installation
 
-Install the package and its required dependencies:
+Install the package and its required dependencies from the repository root—the
+folder containing `pyproject.toml`:
 
 ```bash
+git clone <repo-url>
+cd Three-Body-Problem
 pip install .
 ```
 


### PR DESCRIPTION
## Summary
- clarify that `pip install .` must be run from repo root
- show a short clone example

## Testing
- `pip install -r requirements.txt`
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433c03c9108327b1a853631961baaf