### PR TITLE
Fix simulation launch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ features remain available.
 Start the interactive application with:
 
 ```bash
-python threebody/simulation_full.py
+python -m threebody.simulation_full
 ```
 
 ### Quick Start


### PR DESCRIPTION
## Summary
- correct README to launch simulation module using `-m`

## Testing
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433da9d81c8327afc12dabbc4a4fbb