### PR TITLE
Provide helper for SI positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ x_sim = real_distance_meters / SPACE_SCALE
 Using unscaled metre values will make gravity appear far too weak because the
 distances become millions of times larger than intended.
 
+Alternatively, call :py:meth:`Body.from_meters` to create a body using SI
+coordinates directly. The helper converts the position for you so the resulting
+objects interact as expected.
+
 ## Adjusting Body Trails
 
 Use `Body.set_trail_length(length)` to change how many trail points a body

--- a/threebody/physics.py
+++ b/threebody/physics.py
@@ -24,6 +24,12 @@ class Body:
             f"vel={self.vel.tolist()}, fixed={self.fixed})"
         )
 
+    @staticmethod
+    def from_meters(mass, pos_m, vel_m_s, fixed=False):
+        """Create a :class:`Body` using metre based coordinates."""
+        pos_sim = np.asarray(pos_m, dtype=float) / SPACE_SCALE
+        return Body(mass, pos_sim, vel_m_s, fixed=fixed)
+
 
 def accelerations(bodies, g_constant=G_REAL):
     """Compute accelerations on each body."""

--- a/threebody/rendering.py
+++ b/threebody/rendering.py
@@ -40,6 +40,29 @@ class Body:
             f"vel={self.vel.tolist()}, fixed={self.fixed})"
         )
 
+    @staticmethod
+    def from_meters(mass, x_m, y_m, vx_m_s, vy_m_s, color, radius,
+                    max_trail_length=C.DEFAULT_TRAIL_LENGTH, fixed=False,
+                    name=None, show_trail=True):
+        """Create a body using metre based coordinates.
+
+        Parameters are identical to :class:`Body` except that ``x_m`` and
+        ``y_m`` are specified in real metres rather than simulation units.
+        """
+        return Body(
+            mass,
+            x_m / C.SPACE_SCALE,
+            y_m / C.SPACE_SCALE,
+            vx_m_s,
+            vy_m_s,
+            color,
+            radius,
+            max_trail_length=max_trail_length,
+            fixed=fixed,
+            name=name,
+            show_trail=show_trail,
+        )
+
     def update_physics_state(self, new_pos_sim, new_vel_m_s):
         if not self.fixed:
             self.pos = new_pos_sim


### PR DESCRIPTION
## Summary
- add `Body.from_meters` convenience methods
- document using `Body.from_meters` when supplying real-world distances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444951a38483278b64f69ee9e5ddd0