### PR TITLE
Fix package version loading for tests

### DIFF
--- a/threebody/__init__.py
+++ b/threebody/__init__.py
@@ -1,12 +1,16 @@
 """Three-body simulation utilities."""
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 from .physics import Body, perform_rk4_step, system_energy
 from .integrators import compute_accelerations
 from .constants import G_REAL, SPACE_SCALE, SOFTENING_FACTOR_SQ
 
-__version__ = version("threebody")
+try:
+    __version__ = version("threebody")
+except PackageNotFoundError:
+    # Fallback when package metadata is unavailable (e.g. running from source)
+    __version__ = "0.0.0"
 
 __all__ = [
     'Body',


### PR DESCRIPTION
## Summary
- handle missing distribution metadata in `threebody.__init__`

## Testing
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684461a069688327a4549b5de1f65051