### PR TITLE
Add basic CI with flake8 and pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install flake8 pytest
+      - name: Lint
+        run: flake8 threebody tests
+      - name: Test
+        run: pytest
+


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow that installs dependencies
- run flake8 static checks
- run pytest for unit tests

## Testing
- `flake8 threebody tests && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446286a048832798b414bdb017a061