### PR TITLE
Add long‑term energy and collision conservation tests

### DIFF
--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -29,3 +29,26 @@ def test_collision_bounce_when_merge_false():
     assert removed == []
     assert np.isclose(b1.vel[0], -0.7)
     assert np.isclose(b2.vel[0], 0.7)
+
+def test_collision_bounce_conserves_momentum():
+    b1 = Body(C.EARTH_MASS, -0.0005, 0, 1.0, 0.0, C.WHITE, 5, name="A")
+    b2 = Body(C.EARTH_MASS, 0.0005, 0, -1.0, 0.0, C.WHITE, 5, name="B")
+    bodies = [b1, b2]
+    p_before = b1.mass * b1.vel + b2.mass * b2.vel
+    detect_and_handle_collisions(bodies, merge_on_collision=False)
+    p_after = b1.mass * b1.vel + b2.mass * b2.vel
+    assert np.allclose(p_before, p_after)
+
+
+def test_collision_merge_conserves_momentum():
+    b1 = Body(C.EARTH_MASS, -0.0005, 0, 1.0, 0.0, C.WHITE, 5, name="A")
+    b2 = Body(C.EARTH_MASS, 0.0005, 0, -1.0, 0.0, C.WHITE, 5, name="B")
+    bodies = [b1, b2]
+    p_before = b1.mass * b1.vel + b2.mass * b2.vel
+    removed = detect_and_handle_collisions(bodies, merge_on_collision=True)
+    for idx in removed:
+        bodies.pop(idx)
+    p_after = bodies[0].mass * bodies[0].vel
+    assert np.allclose(p_before, p_after)
+    assert np.isclose(bodies[0].mass, 2 * C.EARTH_MASS)
+

--- a/tests/test_longterm.py
+++ b/tests/test_longterm.py
@@ -1,0 +1,77 @@
+import numpy as np
+import math
+from threebody import Body, perform_rk4_step, system_energy, G_REAL, SPACE_SCALE
+from threebody.integrators import compute_accelerations
+
+
+def _total_momentum(bodies):
+    p = np.zeros(2, dtype=float)
+    for b in bodies:
+        if not getattr(b, "fixed", False):
+            p += b.mass * b.vel
+    return p
+
+
+def _leapfrog_step(pos, vel, masses, fixed_mask, dt, g=G_REAL):
+    acc = compute_accelerations(pos, masses, fixed_mask, g)
+    vel_half = vel + 0.5 * dt * acc
+    pos = pos + dt * vel_half / SPACE_SCALE
+    acc_new = compute_accelerations(pos, masses, fixed_mask, g)
+    vel = vel_half + 0.5 * dt * acc_new
+    return pos, vel
+
+
+def test_energy_momentum_long_term():
+    sun_mass = 1.989e30
+    earth_mass = 5.972e24
+    r = 1.496e11 / SPACE_SCALE
+    v = 29780.0
+
+    sun_vel = np.array([0.0, -(earth_mass / sun_mass) * v])
+    sun = Body(sun_mass, [0.0, 0.0], sun_vel)
+    earth = Body(earth_mass, [r, 0.0], [0.0, v])
+    bodies = [sun, earth]
+
+    e0 = system_energy(bodies, G_REAL)[2]
+    p0 = _total_momentum(bodies)
+
+    dt = 86400.0
+    for _ in range(365 * 5):
+        perform_rk4_step(bodies, dt, G_REAL)
+
+    e1 = system_energy(bodies, G_REAL)[2]
+    p1 = _total_momentum(bodies)
+
+    assert math.isclose(e0, e1, rel_tol=1e-2)
+    assert np.allclose(p0, p1, atol=1e15)
+
+
+def test_leapfrog_integrator_accuracy():
+    sun_mass = 1.989e30
+    earth_mass = 5.972e24
+    r = 1.496e11 / SPACE_SCALE
+    v = 29780.0
+
+    positions = np.array([[0.0, 0.0], [r, 0.0]], dtype=float)
+    velocities = np.array(
+        [[0.0, -(earth_mass / sun_mass) * v], [0.0, v]], dtype=float
+    )
+    masses = np.array([sun_mass, earth_mass], dtype=float)
+    fixed_mask = np.array([False, False], dtype=bool)
+
+    bodies_start = [Body(masses[i], positions[i], velocities[i]) for i in range(2)]
+    e0 = system_energy(bodies_start, G_REAL)[2]
+
+    dt = 86400.0
+    for _ in range(365):
+        positions, velocities = _leapfrog_step(
+            positions, velocities, masses, fixed_mask, dt, G_REAL
+        )
+
+    bodies_end = [Body(masses[i], positions[i], velocities[i]) for i in range(2)]
+    e1 = system_energy(bodies_end, G_REAL)[2]
+
+    earth_final_pos = positions[1]
+    assert math.isclose(e0, e1, rel_tol=1e-6)
+    assert np.allclose(earth_final_pos, [r, 0.0], atol=5e-2)
+


### PR DESCRIPTION
## Summary
- measure energy and momentum drift over several years
- add leapfrog accuracy test
- check momentum conservation when bodies bounce or merge

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446282ca8483278b9696cf9d5e232e