### PR TITLE
Enable 3‑D physics vectors

### DIFF
--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -10,11 +10,12 @@ def test_accelerations_fixed_body():
     b_free = Body(1.0, [1.0, 0.0], [0.0, 0.0])
     acc = accelerations([b_fixed, b_free], g_constant=1.0)
     # fixed body should have zero acceleration
-    assert np.allclose(acc[0], [0.0, 0.0])
+    assert np.allclose(acc[0], [0.0, 0.0, 0.0])
     # expected acceleration on free body towards the fixed body
     expected = -1.0 / (SPACE_SCALE ** 2 + 1.0)
     assert math.isclose(acc[1][0], expected, rel_tol=1e-12)
     assert math.isclose(acc[1][1], 0.0, abs_tol=1e-12)
+    assert math.isclose(acc[1][2], 0.0, abs_tol=1e-12)
 
 
 def test_accelerations_zero_distance():
@@ -22,8 +23,8 @@ def test_accelerations_zero_distance():
     b2 = Body(2.0, [0.0, 0.0], [0.0, 0.0])
     acc = accelerations([b1, b2], g_constant=1.0)
     # zero distance should result in zero acceleration due to skip
-    assert np.allclose(acc[0], [0.0, 0.0])
-    assert np.allclose(acc[1], [0.0, 0.0])
+    assert np.allclose(acc[0], [0.0, 0.0, 0.0])
+    assert np.allclose(acc[1], [0.0, 0.0, 0.0])
 
 
 def test_rk4_step_keeps_fixed_body_static():
@@ -31,8 +32,8 @@ def test_rk4_step_keeps_fixed_body_static():
     mover = Body(1.0, [1.0, 0.0], [0.0, 1.0])
     bodies = [fixed, mover]
     perform_rk4_step(bodies, dt=1.0, g_constant=0.0)
-    assert np.allclose(fixed.pos, [0.0, 0.0])
-    assert np.allclose(fixed.vel, [0.0, 0.0])
+    assert np.allclose(fixed.pos, [0.0, 0.0, 0.0])
+    assert np.allclose(fixed.vel, [0.0, 0.0, 0.0])
 
 
 def test_rk4_step_zero_distance():

--- a/threebody/physics.py
+++ b/threebody/physics.py
@@ -12,10 +12,33 @@ from .integrators import compute_accelerations, rk4_step_arrays
 
 class Body:
     """Simple body representation for physics computations."""
-    def __init__(self, mass, pos, vel, fixed=False):
+
+    def __init__(self, mass, pos, vel, fixed: bool = False):
+        """Create a body.
+
+        Parameters
+        ----------
+        mass : float
+            Mass of the body in kilograms.
+        pos : array-like
+            Initial position. 2-D values are padded with ``z=0``.
+        vel : array-like
+            Initial velocity. 2-D values are padded with ``z=0``.
+        fixed : bool, optional
+            If True the body does not move when integrated.
+        """
+
         self.mass = float(mass)
-        self.pos = np.asarray(pos, dtype=float)
-        self.vel = np.asarray(vel, dtype=float)
+        p = np.asarray(pos, dtype=float)
+        if p.size == 2:
+            p = np.append(p, 0.0)
+        self.pos = p.astype(float)
+
+        v = np.asarray(vel, dtype=float)
+        if v.size == 2:
+            v = np.append(v, 0.0)
+        self.vel = v.astype(float)
+
         self.fixed = fixed
 
     def __repr__(self):

--- a/threebody/physics_utils.py
+++ b/threebody/physics_utils.py
@@ -28,7 +28,7 @@ def calculate_system_energies(bodies, g_constant):
 
 
 def calculate_system_momentum(bodies):
-    total_momentum = np.zeros(2, dtype=np.float64)
+    total_momentum = np.zeros(3, dtype=np.float64)
     for body in bodies:
         if body.fixed:
             continue
@@ -38,8 +38,8 @@ def calculate_system_momentum(bodies):
 
 def calculate_center_of_mass(bodies):
     total_mass = 0.0
-    weighted_pos_sum = np.zeros(2, dtype=np.float64)
-    weighted_vel_sum = np.zeros(2, dtype=np.float64)
+    weighted_pos_sum = np.zeros(3, dtype=np.float64)
+    weighted_vel_sum = np.zeros(3, dtype=np.float64)
     has_mass = False
     for body in bodies:
         if not body.fixed and body.mass > 0:
@@ -53,8 +53,8 @@ def calculate_center_of_mass(bodies):
             if len(fixed_bodies) > 0:
                 com_pos_sim = sum(b.pos for b in fixed_bodies) / len(fixed_bodies)
             else:
-                com_pos_sim = np.array([0.0, 0.0])
-            com_vel_m_s = np.zeros(2)
+                com_pos_sim = np.array([0.0, 0.0, 0.0])
+            com_vel_m_s = np.zeros(3)
             return com_pos_sim, com_vel_m_s
         return None, None
     com_pos_sim = weighted_pos_sum / total_mass
@@ -64,7 +64,7 @@ def calculate_center_of_mass(bodies):
 
 def calculate_accelerations_for_all(bodies, g_constant):
     if not bodies:
-        return np.zeros((0, 2), dtype=np.float64)
+        return np.zeros((0, 3), dtype=np.float64)
 
     positions = np.array([b.pos for b in bodies])
     masses = np.array([b.mass for b in bodies])
@@ -87,7 +87,7 @@ def perform_rk4_step(bodies, dt, g_constant):
 
 def calculate_accelerations_from_temp(temp_bodies_list, g_constant):
     if not temp_bodies_list:
-        return np.zeros((0, 2), dtype=np.float64)
+        return np.zeros((0, 3), dtype=np.float64)
 
     positions = np.array([tb['pos'] for tb in temp_bodies_list])
     masses = np.array([tb['mass'] for tb in temp_bodies_list])
@@ -147,10 +147,10 @@ def adaptive_rk4_step(bodies, current_dt, g_constant, error_tolerance, use_bound
                     body.handle_boundary_collision(bounds_sim)
                 else:
                     new_pos, new_vel = apply_boundary_conditions_jit(
-                        body.pos, body.vel, bounds_sim, 0.8
+                        body.pos[:2], body.vel[:2], bounds_sim, 0.8
                     )
-                    body.pos = new_pos
-                    body.vel = new_vel
+                    body.pos[:2] = new_pos
+                    body.vel[:2] = new_vel
         return dt, dt_new
     else:
         return 0.0, dt_new


### PR DESCRIPTION
## Summary
- expand `Body` to pad 2‑D coordinates to 3‑D
- update integrators to work with 3‑D arrays
- adjust rendering `Body` so it stores z components but still draws in 2‑D
- ensure boundary handling slices to XY plane
- revise physics utilities and tests for new dimensions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446280b7b483279336388297212ddf