### PR TITLE
Add symplectic integrator option

### DIFF
--- a/threebody/__init__.py
+++ b/threebody/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-from .physics import Body, perform_rk4_step, system_energy
+from .physics import Body, perform_rk4_step, perform_symplectic_step, system_energy
 from .integrators import compute_accelerations
 from .constants import G_REAL, SPACE_SCALE, SOFTENING_FACTOR_SQ
 
@@ -15,6 +15,7 @@ except PackageNotFoundError:
 __all__ = [
     'Body',
     'perform_rk4_step',
+    'perform_symplectic_step',
     'system_energy',
     'compute_accelerations',
     'G_REAL',

--- a/threebody/physics.py
+++ b/threebody/physics.py
@@ -7,7 +7,11 @@ more feature rich :class:`~threebody.rendering.Body` instead.
 import numpy as np
 
 from .constants import G_REAL, SPACE_SCALE
-from .integrators import compute_accelerations, rk4_step_arrays
+from .integrators import (
+    compute_accelerations,
+    rk4_step_arrays,
+    symplectic_step_arrays,
+)
 
 
 class Body:
@@ -55,6 +59,26 @@ def perform_rk4_step(bodies, dt, g_constant=G_REAL):
     fixed_mask = np.array([b.fixed for b in bodies], dtype=bool)
 
     new_pos, new_vel = rk4_step_arrays(
+        positions, velocities, masses, fixed_mask, dt, g_constant
+    )
+
+    for b, p, v, fixed in zip(bodies, new_pos, new_vel, fixed_mask):
+        if not fixed:
+            b.pos = p
+            b.vel = v
+
+
+def perform_symplectic_step(bodies, dt, g_constant=G_REAL):
+    """Advance bodies using a Leapfrog integrator."""
+    if not bodies:
+        return
+
+    positions = np.array([b.pos for b in bodies], dtype=float)
+    velocities = np.array([b.vel for b in bodies], dtype=float)
+    masses = np.array([b.mass for b in bodies], dtype=float)
+    fixed_mask = np.array([b.fixed for b in bodies], dtype=bool)
+
+    new_pos, new_vel = symplectic_step_arrays(
         positions, velocities, masses, fixed_mask, dt, g_constant
     )
 

--- a/threebody/physics_utils.py
+++ b/threebody/physics_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 from . import constants as C
 from .physics import Body as PhysicsBody
 from .jit import apply_boundary_conditions_jit
-from .integrators import compute_accelerations, rk4_step_arrays
+from .integrators import compute_accelerations, rk4_step_arrays, symplectic_step_arrays
 
 
 def calculate_system_energies(bodies, g_constant):
@@ -83,6 +83,19 @@ def perform_rk4_step(bodies, dt, g_constant):
     fixed_mask = np.array([b.fixed for b in bodies])
 
     return rk4_step_arrays(positions, velocities, masses, fixed_mask, dt, g_constant)
+
+
+def perform_symplectic_step(bodies, dt, g_constant):
+    """Advance bodies using a Leapfrog integrator."""
+    if not bodies:
+        return np.array([]), np.array([])
+
+    positions = np.array([b.pos for b in bodies])
+    velocities = np.array([b.vel for b in bodies])
+    masses = np.array([b.mass for b in bodies])
+    fixed_mask = np.array([b.fixed for b in bodies])
+
+    return symplectic_step_arrays(positions, velocities, masses, fixed_mask, dt, g_constant)
 
 
 def calculate_accelerations_from_temp(temp_bodies_list, g_constant):


### PR DESCRIPTION
## Summary
- implement `symplectic_step_arrays` and companion helpers
- expose symplectic integrator from package
- allow choosing integrator in the full simulation

## Testing
- `pip install -q -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844627eb5cc83278f0aeefc7db7d849