### PR TITLE
Update CI pipeline for optional deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,22 +2,28 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
+    branches: ['**']
   pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .
           pip install flake8 pytest
+          # Optional GPU acceleration packages
+          pip install cupy-cuda11x || true
       - name: Lint
         run: flake8 threebody tests
       - name: Test


### PR DESCRIPTION
## Summary
- run CI on every push
- add Python 3.9-3.11 matrix
- install optional CuPy dependency

## Testing
- `flake8 threebody tests` *(fails: line too long and blank line issues)*
- `pytest -q` *(fails: broadcasting errors in `test_longterm.py`)*

------
https://chatgpt.com/codex/tasks/task_e_6844674e105c8327a775de22d613b40d