### PR TITLE
Add integrator selection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ python -m threebody.simulation_full
 ```
 
 Use `--softening-length` to override the gravitational softening length in
-metres when launching the simulation.
+metres when launching the simulation. Additional command line flags:
+
+```
+--integrator {rk4,symplectic}  Integration scheme (default rk4)
+--time-step SECONDS            Initial step size
+--error-tolerance VALUE        Adaptive RK4 tolerance
+```
 
 ### Quick Start
 
@@ -70,6 +76,8 @@ Two integrators are provided:
 * **Adaptive RK4** via :py:meth:`threebody.physics_utils.adaptive_rk4_step` –
   automatically adjusts the time step to keep the estimated local error below
   ``ERROR_TOLERANCE``.
+* **Symplectic Leapfrog** via ``--integrator symplectic`` – lower accuracy but
+  good long-term stability.
 
 These are standard explicit Runge–Kutta methods as described in
 [Hairer et&nbsp;al.](https://doi.org/10.1007/978-3-642-05415-1).

--- a/threebody/physics_utils.py
+++ b/threebody/physics_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 from . import constants as C
 from .physics import Body as PhysicsBody
 from .jit import apply_boundary_conditions_jit
-from .integrators import compute_accelerations, rk4_step_arrays
+from .integrators import compute_accelerations, rk4_step_arrays, leapfrog_step_arrays
 
 
 def calculate_system_energies(bodies, g_constant):
@@ -83,6 +83,18 @@ def perform_rk4_step(bodies, dt, g_constant):
     fixed_mask = np.array([b.fixed for b in bodies])
 
     return rk4_step_arrays(positions, velocities, masses, fixed_mask, dt, g_constant)
+
+
+def perform_leapfrog_step(bodies, dt, g_constant):
+    if not bodies:
+        return np.array([]), np.array([])
+
+    positions = np.array([b.pos for b in bodies])
+    velocities = np.array([b.vel for b in bodies])
+    masses = np.array([b.mass for b in bodies])
+    fixed_mask = np.array([b.fixed for b in bodies])
+
+    return leapfrog_step_arrays(positions, velocities, masses, fixed_mask, dt, g_constant)
 
 
 def calculate_accelerations_from_temp(temp_bodies_list, g_constant):


### PR DESCRIPTION
## Summary
- expose `--integrator`, `--time-step` and `--error-tolerance` arguments
- support a symplectic leapfrog integrator
- document new CLI flags in README

## Testing
- `pytest -q` *(fails: test_energy_momentum_long_term)*

------
https://chatgpt.com/codex/tasks/task_e_6844674ea3588327a239610374f3665f