### PR TITLE
Add CuPy acceleration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ Numba is used for optional JIT acceleration. If it is missing or fails to
 initialize, the simulation automatically falls back to pure Python code so all
 features remain available.
 
+CuPy can be installed to run the core gravitational calculation on a CUDA GPU.
+Install a build matching your CUDA toolkit, for example:
+
+```bash
+pip install cupy-cuda12x
+```
+
+With CuPy available and a compatible GPU present, `compute_accelerations`
+automatically performs its work on the GPU. If no GPU is detected it silently
+falls back to the CPU.
+
 ## Running the Simulation
 
 Start the interactive application with:


### PR DESCRIPTION
## Summary
- implement optional CuPy-based compute_accelerations
- fall back to CPU when CuPy or a CUDA GPU isn't available
- document how to install CuPy for GPU acceleration

## Testing
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q` *(fails: test_energy_momentum_long_term)*

------
https://chatgpt.com/codex/tasks/task_e_6844674c61808327a4491b3f37a2528e