### PR TITLE
Expose CLI softening parameter with preset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Start the interactive application with:
 python -m threebody.simulation_full
 ```
 
-Use `--softening-length` to override the gravitational softening length in
-metres when launching the simulation.
+Use `--softening-length` to override the global gravitational softening length
+in metres. Individual presets may specify their own value which takes
+precedence over the command-line option.
 
 ### Quick Start
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,7 +1,20 @@
 import importlib
 import threebody.constants as C
+from threebody.presets import get_preset_softening_length, PRESET_SOFTENING_LENGTHS
 
 
 def test_softening_factor_matches_length():
     importlib.reload(C)
     assert C.SOFTENING_FACTOR_SQ == C.SOFTENING_LENGTH**2
+
+
+def test_get_preset_softening_length():
+    importlib.reload(C)
+    preset_value = get_preset_softening_length("Sun & Earth", override=0.5)
+    assert preset_value == PRESET_SOFTENING_LENGTHS["Sun & Earth"]
+
+    override_value = get_preset_softening_length("Empty", override=0.5)
+    assert override_value == 0.5
+
+    default_value = get_preset_softening_length("Empty")
+    assert default_value == C.SOFTENING_LENGTH

--- a/tests/test_longterm.py
+++ b/tests/test_longterm.py
@@ -8,7 +8,7 @@ def _total_momentum(bodies):
     p = np.zeros(2, dtype=float)
     for b in bodies:
         if not getattr(b, "fixed", False):
-            p += b.mass * b.vel
+            p += b.mass * b.vel[:2]
     return p
 
 

--- a/threebody/integrators.py
+++ b/threebody/integrators.py
@@ -33,12 +33,14 @@ def compute_accelerations(
 
     n = len(masses)
     if n == 0:
-        return np.zeros((0, 3), dtype=np.float64)
+        return np.zeros((0, positions.shape[1]), dtype=np.float64)
 
     dim = positions.shape[1]
+    use_2d = False
     if dim == 2:
         positions = np.hstack([positions, np.zeros((n, 1), dtype=positions.dtype)])
         dim = 3
+        use_2d = True
 
     acc = np.zeros((n, dim), dtype=np.float64)
     for i in range(n):
@@ -58,6 +60,9 @@ def compute_accelerations(
         factors = g_constant * masses / (dist_sq_m + C.SOFTENING_FACTOR_SQ)
 
         acc[i] = np.sum(r_vec * (inv_dist[:, None] * factors[:, None]), axis=0)
+
+    if use_2d:
+        acc = acc[:, :2]
 
     return acc
 

--- a/threebody/presets.py
+++ b/threebody/presets.py
@@ -193,4 +193,22 @@ PRESETS = {
 }
 
 # Optional softening length (in metres) per preset
-PRESET_SOFTENING_LENGTHS = {name: C.SOFTENING_LENGTH for name in PRESETS}
+# ``None`` means use the global default or command-line override.
+PRESET_SOFTENING_LENGTHS = {name: None for name in PRESETS}
+# Example overrides for specific scenarios
+PRESET_SOFTENING_LENGTHS["Sun & Earth"] = 1e6
+PRESET_SOFTENING_LENGTHS["Figure 8"] = 5e5
+
+
+def get_preset_softening_length(preset_name: str, override: float | None = None) -> float:
+    """Return the softening length for a preset.
+
+    A value defined in :data:`PRESET_SOFTENING_LENGTHS` takes precedence over any
+    command-line override. If neither provides a value the global default from
+    :mod:`threebody.constants` is used.
+    """
+    if preset_name in PRESET_SOFTENING_LENGTHS and PRESET_SOFTENING_LENGTHS[preset_name] is not None:
+        return float(PRESET_SOFTENING_LENGTHS[preset_name])
+    if override is not None:
+        return float(override)
+    return float(C.SOFTENING_LENGTH)

--- a/threebody/simulation_full.py
+++ b/threebody/simulation_full.py
@@ -39,7 +39,7 @@ from .constants import *
 from . import constants as C
 from . import __version__
 from .utils import mass_to_display, distance_to_display, time_to_display
-from .presets import PRESETS
+from .presets import PRESETS, get_preset_softening_length
 from .rendering import Body, render_gravitational_field
 from .physics_utils import calculate_center_of_mass, perform_rk4_step, adaptive_rk4_step, detect_and_handle_collisions, get_world_bounds_sim
 
@@ -246,8 +246,7 @@ def main(softening_length_override=None):
 
         preset_data = PRESETS[preset_name]
 
-        preset_soft = PRESET_SOFTENING_LENGTHS.get(preset_name, C.SOFTENING_LENGTH)
-        new_soft = softening_length_override if softening_length_override is not None else preset_soft
+        new_soft = get_preset_softening_length(preset_name, softening_length_override)
         C.SOFTENING_LENGTH = float(new_soft)
         C.SOFTENING_FACTOR_SQ = C.SOFTENING_LENGTH ** 2
         bodies = []


### PR DESCRIPTION
## Summary
- allow presets to set their own softening length and add helper to resolve the value
- honour that logic in `simulation_full` and document the option
- fix `compute_accelerations` to preserve dimensionality
- adjust longterm tests for 3‑D velocities
- add unit tests for the new helper

## Testing
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844674aa66c8327b0dde15ac54f745a