### PR TITLE
Add symplectic integrator option

### DIFF
--- a/tests/test_longterm.py
+++ b/tests/test_longterm.py
@@ -5,7 +5,7 @@ from threebody.integrators import compute_accelerations
 
 
 def _total_momentum(bodies):
-    p = np.zeros(2, dtype=float)
+    p = np.zeros(3, dtype=float)
     for b in bodies:
         if not getattr(b, "fixed", False):
             p += b.mass * b.vel

--- a/threebody/presets.py
+++ b/threebody/presets.py
@@ -194,3 +194,7 @@ PRESETS = {
 
 # Optional softening length (in metres) per preset
 PRESET_SOFTENING_LENGTHS = {name: C.SOFTENING_LENGTH for name in PRESETS}
+
+# Default integrator per preset
+PRESET_INTEGRATORS = {name: "rk4" for name in PRESETS}
+PRESET_INTEGRATORS["Figure 8"] = "symplectic"


### PR DESCRIPTION
## Summary
- introduce `symplectic_step_arrays` and supporting wrapper
- return accelerations in original dimensionality
- allow presets to specify a default integrator
- expose integrator choice via CLI and status display
- adjust long term tests for 3‑D velocities

## Testing
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446746c9108327a714a0d42dd1be45