### PR TITLE
Fix zoom for simulation units

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ distances become millions of times larger than intended.  The same scale is used
 internally for presets so that real solar system parameters remain numerically
 stable.
 
+The default camera zoom assumes positions are given in these scaled units. With
+``ZOOM_BASE`` defined as ``500 * SPACE_SCALE / AU`` one astronomical unit spans
+roughly 500 pixels on screen when using the built‑in presets.
+
 Alternatively, call :py:meth:`Body.from_meters` to create a body using SI
 coordinates directly. The helper converts the position for you so the resulting
 objects interact as expected.  This is important because the gravitational

--- a/threebody/constants.py
+++ b/threebody/constants.py
@@ -58,7 +58,8 @@ MAX_TIME_STEP = 3600
 FIELD_RESOLUTION = 30
 SHOW_GRAV_FIELD = False
 SHOW_TRAILS = True
-ZOOM_BASE = 1.0 / (AU / 500)
+# Default zoom so that one astronomical unit spans roughly 500 pixels
+ZOOM_BASE = 500 * SPACE_SCALE / AU
 INITIAL_PAN_OFFSET = np.array(
     [(WIDTH - UI_SIDEBAR_WIDTH) / 2, (HEIGHT - UI_BOTTOM_HEIGHT) / 2], dtype=np.float64
 )

--- a/threebody/rendering.py
+++ b/threebody/rendering.py
@@ -137,8 +137,9 @@ class Body:
                         pygame.draw.line(screen, self.color, start_pos, end_pos, 1)
                     except Exception:
                         pass
-        effective_zoom_scale = max(0.1, zoom ** C.BODY_ZOOM_SCALING_POWER)
-        draw_radius = max(3, int(self.radius_pixels * effective_zoom_scale))
+        effective_zoom_scale = zoom ** C.BODY_ZOOM_SCALING_POWER
+        # Prevent tiny values from rounding to zero so bodies remain visible
+        draw_radius = max(1, int(self.radius_pixels * effective_zoom_scale))
         if (draw_pos[0] + draw_radius < 0 or draw_pos[0] - draw_radius > sim_width_pixels or
                 draw_pos[1] + draw_radius < 0 or draw_pos[1] - draw_radius > sim_height_pixels):
             return
@@ -198,7 +199,9 @@ def render_gravitational_field(screen, bodies, g_constant, zoom, pan_offset):
             world_pos_sim = (screen_pos - pan_offset) / (zoom + 1e-18)
             potential_at_point = 0.0
             for body in bodies:
-                dist_vec_sim = body.pos - world_pos_sim
+                # body.pos is 3-D while world_pos_sim is 2-D, so only compare
+                # in the rendered plane to avoid shape mismatches
+                dist_vec_sim = body.pos[:2] - world_pos_sim
                 dist_sq_sim = np.dot(dist_vec_sim, dist_vec_sim)
                 if dist_sq_sim > 1e-18:
                     dist_meters = np.sqrt(dist_sq_sim) * C.SPACE_SCALE


### PR DESCRIPTION
## Summary
- adjust `ZOOM_BASE` so 1 AU equals ~500 pixels when using scaled units
- document zoom behaviour in README

## Testing
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68458971ec8c83279b5ec1c54fdc4ed1