### PR TITLE
Implement preset loading and input handling

### DIFF
--- a/threebody/physics.py
+++ b/threebody/physics.py
@@ -43,6 +43,19 @@ class Body:
 
         self.fixed = fixed
 
+    def update_physics_state(self, new_pos_sim, new_vel_m_s):
+        """Update the body's position and velocity."""
+        if self.fixed:
+            return
+        p = np.asarray(new_pos_sim, dtype=float).reshape(-1)
+        if p.size < 3:
+            p = np.pad(p, (0, 3 - p.size))
+        v = np.asarray(new_vel_m_s, dtype=float).reshape(-1)
+        if v.size < 3:
+            v = np.pad(v, (0, 3 - v.size))
+        self.pos = p[:3]
+        self.vel = v[:3]
+
     def __repr__(self):
         return (
             f"Body(mass={self.mass}, pos={self.pos.tolist()}, "

--- a/threebody/physics_utils.py
+++ b/threebody/physics_utils.py
@@ -157,6 +157,7 @@ def detect_and_handle_collisions(bodies, merge_on_collision=False):
         else:
             mass_ratio = body.mass / C.EARTH_MASS
             radius_sim = earth_radius_sim * (mass_ratio ** (1/3))
+        radius_sim *= C.COLLISION_DISTANCE_FACTOR
         physical_radii_sim.append(max(radius_sim, 0.001 * earth_radius_sim))
         
     for i in range(num_bodies):


### PR DESCRIPTION
## Summary
- load presets from `presets.py`
- implement runtime input handling for pygame and UI
- allow overriding softening length from CLI
- expose physics body update helper
- expand collision radius using the configured distance factor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a371b934832795610ee001bf06ee