### PR TITLE
Add NASA ephemerides support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,25 @@ the lightweight `threebody.physics` module and the interactive simulation.
 The interactive application uses a richer `Body` implementation found in
 `threebody.rendering` which adds drawing and trail management utilities.
 
+## NASA Ephemerides
+
+High precision starting positions can be loaded from NASA JPL SPK files. Use the
+new helpers in ``threebody.nasa`` with a kernel such as ``de421.bsp``:
+
+```python
+from threebody import load_ephemeris, create_body
+from threebody.constants import EARTH_MASS, SOLAR_MASS
+from datetime import datetime
+
+ephem = load_ephemeris("de421.bsp")
+epoch = datetime(2024, 1, 1)
+sun = create_body(ephem, 10, epoch, SOLAR_MASS, name="Sun")
+earth = create_body(ephem, 399, epoch, EARTH_MASS, name="Earth")
+```
+
+The ``de421.bsp`` kernel can be downloaded from NASA archives or the
+[``python-jplephem`` repository](https://github.com/brandon-rhodes/python-jplephem/blob/master/de421.bsp).
+
 ## Integrator Choices
 
 Three integrators are provided:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,5 @@ dependencies = [
     "numba",
     "pygame-ce>=2.5.4",
     "pygame_gui",
+    "jplephem",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 numba
 pygame-ce>=2.5.4
 pygame_gui
+jplephem

--- a/threebody/__init__.py
+++ b/threebody/__init__.py
@@ -12,6 +12,7 @@ from .constants import (
     C_LIGHT,
 )
 
+from .nasa import load_ephemeris, body_state, create_body
 try:
     __version__ = version("threebody")
 except PackageNotFoundError:
@@ -29,4 +30,7 @@ __all__ = [
     "SOFTENING_FACTOR_SQ",
     "C_LIGHT",
     "__version__",
+    "load_ephemeris",
+    "body_state",
+    "create_body",
 ]

--- a/threebody/nasa.py
+++ b/threebody/nasa.py
@@ -1,0 +1,38 @@
+"""NASA JPL ephemeris helpers."""
+
+from datetime import datetime
+from typing import Optional
+
+import numpy as np
+from jplephem.spk import SPK
+
+from .physics import Body
+from .constants import SPACE_SCALE
+
+
+def load_ephemeris(path: str) -> SPK:
+    """Load a JPL SPK ephemeris file."""
+    return SPK.open(path)
+
+
+def body_state(ephem: SPK, target: int, epoch: datetime) -> tuple[np.ndarray, np.ndarray]:
+    """Return position and velocity in simulation units and m/s."""
+    jd = epoch.timestamp() / 86400.0 + 2440587.5
+    pos, vel = ephem[0, target].compute_and_differentiate(jd)
+    pos = (pos * 1000.0) / SPACE_SCALE
+    vel = vel * 1000.0
+    return pos, vel
+
+
+def create_body(
+    ephem: SPK,
+    target: int,
+    epoch: datetime,
+    mass: float,
+    *,
+    name: Optional[str] = None,
+) -> Body:
+    """Create a :class:`Body` instance from ephemeris data."""
+    pos, vel = body_state(ephem, target, epoch)
+    return Body(mass, pos, vel, name=name or str(target))
+


### PR DESCRIPTION
## Summary
- provide helpers for reading NASA JPL SPK kernels
- expose ephemeris helpers in package `__all__`
- document how to load SPK data from NASA
- require `jplephem` for SPK file handling

## Testing
- `pip install -r requirements.txt`
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a8e2f1e4832793b7b6246ff3b1cd