### PR TITLE
Fix errstate context in integrators

### DIFF
--- a/threebody/integrators.py
+++ b/threebody/integrators.py
@@ -67,7 +67,7 @@ def compute_accelerations(
         # 计算牛顿引力
         dist_sq_m = dist_sq_sim * scale_sq
         # 使用 np.errstate 避免除零警告
-
+        with xp.errstate(divide="ignore", invalid="ignore"):
             # 软化因子
             denominator = dist_sq_m + C.SOFTENING_FACTOR_SQ
             factor = g_constant / denominator


### PR DESCRIPTION
## Summary
- add missing `xp.errstate` context to avoid divide-by-zero warnings in `integrators.compute_accelerations`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c3d530308327b39e4050b3502b43