### PR TITLE
Fix integrator indentation and show demo bodies

### DIFF
--- a/threebody/integrators.py
+++ b/threebody/integrators.py
@@ -67,7 +67,7 @@ def compute_accelerations(
         # 计算牛顿引力
         dist_sq_m = dist_sq_sim * scale_sq
         # 使用 np.errstate 避免除零警告
-
+        with xp.errstate(divide="ignore", invalid="ignore"):
             # 软化因子
             denominator = dist_sq_m + C.SOFTENING_FACTOR_SQ
             factor = g_constant / denominator

--- a/threebody/simulation_full.py
+++ b/threebody/simulation_full.py
@@ -27,7 +27,9 @@ def main():
     screen = pygame.display.set_mode((C.WIDTH, C.HEIGHT))
     pygame.display.set_caption("Three Body Simulation")
 
-    bodies = _create_bodies("Empty")
+    bodies = _create_bodies("Sun & Earth")
+    zoom = C.ZOOM_BASE
+    pan_offset = C.INITIAL_PAN_OFFSET
     clock = pygame.time.Clock()
     running = True
     while running:
@@ -37,7 +39,10 @@ def main():
         step_simulation(bodies, C.TIME_STEP_BASE, C.G_REAL, integrator_type="RK4")
         screen.fill(C.BLACK)
         for b in bodies:
-            pass
+            if hasattr(b, "update_trail"):
+                b.update_trail(zoom, pan_offset)
+            if hasattr(b, "draw"):
+                b.draw(screen, zoom, pan_offset, draw_labels=False)
         pygame.display.flip()
         clock.tick(60)
 


### PR DESCRIPTION
## Summary
- resolve indentation issue in `compute_accelerations`
- show bodies in the example simulation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c0318f108327ae21efb079f7318f