### PR TITLE
Improve simulation UI with pause and help overlay

### DIFF
--- a/threebody/simulation_full.py
+++ b/threebody/simulation_full.py
@@ -26,6 +26,13 @@ def main():
     pygame.init()
     screen = pygame.display.set_mode((C.WIDTH, C.HEIGHT))
     pygame.display.set_caption("Three Body Simulation")
+    font = pygame.font.Font(None, 20)
+    help_lines = [
+        "SPACE: pause/resume",
+        "H: toggle help",
+    ]
+    show_help = False
+    paused = False
 
     bodies = _create_bodies("Sun & Earth")
     zoom = C.ZOOM_BASE
@@ -36,13 +43,29 @@ def main():
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
-        step_simulation(bodies, C.TIME_STEP_BASE, C.G_REAL, integrator_type="RK4")
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_SPACE:
+                    paused = not paused
+                elif event.key == pygame.K_h:
+                    show_help = not show_help
+        if not paused:
+            step_simulation(bodies, C.TIME_STEP_BASE, C.G_REAL, integrator_type="RK4")
         screen.fill(C.BLACK)
         for b in bodies:
             if hasattr(b, "update_trail"):
                 b.update_trail(zoom, pan_offset)
             if hasattr(b, "draw"):
                 b.draw(screen, zoom, pan_offset, draw_labels=False)
+        if show_help:
+            for i, line in enumerate(help_lines):
+                text = font.render(line, True, C.WHITE)
+                screen.blit(text, (10, 10 + i * 20))
+        if paused:
+            pause_text = font.render("PAUSED", True, C.WHITE)
+            screen.blit(pause_text, (10, C.HEIGHT - 30))
+        fps_text = font.render(f"FPS: {clock.get_fps():.1f}", True, C.WHITE)
+        screen.blit(fps_text, (C.WIDTH - 100, 10))
+
         pygame.display.flip()
         clock.tick(60)
 


### PR DESCRIPTION
## Summary
- add keyboard controls to `simulation_full`
- display FPS, pause indicator, and help overlay

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ccc4373c832797c4fbef8e2f004c