### PR TITLE
Add ephemeris download helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ earth = create_body(ephem, 399, epoch, EARTH_MASS, name="Earth")
 The ``de421.bsp`` kernel can be downloaded from NASA archives or the
 [``python-jplephem`` repository](https://github.com/brandon-rhodes/python-jplephem/blob/master/de421.bsp).
 
+``threebody.nasa`` also provides ``download_ephemeris`` to fetch a kernel
+programmatically. A command line wrapper is installed as
+``threebody-download``:
+
+```bash
+threebody-download https://example.com/de421.bsp kernels/
+```
+
 ## Integrator Choices
 
 Three integrators are provided:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,4 @@ dependencies = [
 
 [project.scripts]
 threebody-sim = "threebody.simulation_full:main"
+threebody-download = "threebody.nasa:main"

--- a/tests/test_nasa_download.py
+++ b/tests/test_nasa_download.py
@@ -1,0 +1,34 @@
+import http.server
+import socketserver
+import threading
+import os
+from pathlib import Path
+
+from threebody.nasa import download_ephemeris
+
+
+def test_download_ephemeris(tmp_path):
+    data = b"abc123"
+    source = tmp_path / "source.bsp"
+    source.write_bytes(data)
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def log_message(self, format, *args):
+            pass
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    httpd = socketserver.TCPServer(("localhost", 0), Handler)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://localhost:{port}/source.bsp"
+        dest = tmp_path / "out.bsp"
+        path = download_ephemeris(url, dest)
+        assert path.exists()
+        assert path.read_bytes() == data
+    finally:
+        httpd.shutdown()
+        thread.join()
+        os.chdir(cwd)

--- a/threebody/__init__.py
+++ b/threebody/__init__.py
@@ -12,7 +12,7 @@ from .constants import (
     C_LIGHT,
 )
 
-from .nasa import load_ephemeris, body_state, create_body
+from .nasa import load_ephemeris, body_state, create_body, download_ephemeris
 try:
     __version__ = version("threebody")
 except PackageNotFoundError:
@@ -33,4 +33,5 @@ __all__ = [
     "load_ephemeris",
     "body_state",
     "create_body",
+    "download_ephemeris",
 ]


### PR DESCRIPTION
## Summary
- add new helper `download_ephemeris` and CLI `threebody-download`
- expose the helper from the package
- document ephemeris download workflow
- test ephemeris downloads using a temporary HTTP server

## Testing
- `pip install -r requirements.txt`
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d474226083279fd2a9a337767f5b