### PR TITLE
Add energy drift export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ retains. The length is clamped between `MIN_TRAIL_LENGTH` and
 `True` the bodies combine into one mass; otherwise they bounce using a simple
 elastic collision model.
 
+## Energy Monitoring
+
+The window shows a chart of the percentage energy drift over time.  Call
+``EnergyMonitor.export_csv()`` to save this history for offline analysis:
+
+```python
+from threebody.analysis import EnergyMonitor
+energy_monitor = EnergyMonitor()
+energy_monitor.export_csv("energy.csv")
+```
+
 ## Configuration Parameters
 
 The `threebody.constants` module exposes numerous tuning options. Important

--- a/tests/test_energy_monitor.py
+++ b/tests/test_energy_monitor.py
@@ -9,3 +9,17 @@ def test_energy_monitor_basic_update():
     em.set_initial_energy(bodies, g_constant=1.0)
     em.update(bodies, g_constant=1.0)
     assert len(em.history) == 1
+
+
+def test_energy_monitor_export_csv(tmp_path):
+    em = EnergyMonitor()
+    bodies = [Body(1.0, [0.0, 0.0], [0.0, 0.0]), Body(1.0, [1.0, 0.0], [0.0, 0.0])]
+    em.set_initial_energy(bodies, g_constant=1.0)
+    for _ in range(3):
+        em.update(bodies, g_constant=1.0)
+
+    out_file = tmp_path / "hist.csv"
+    em.export_csv(out_file)
+    lines = out_file.read_text().strip().splitlines()
+    assert lines[0] == "step,energy_drift_percent"
+    assert len(lines) == 4

--- a/threebody/analysis.py
+++ b/threebody/analysis.py
@@ -3,6 +3,8 @@ import pygame
 from collections import deque
 from . import constants as C
 from .physics_utils import calculate_system_energies
+import csv
+import os
 
 def calculate_orbital_elements(body, central_body):
     """计算并返回一个天体相对于中心天体的轨道根数。"""
@@ -90,3 +92,26 @@ class EnergyMonitor:
         font = pygame.font.Font(None, 18)
         text = font.render(f"能量漂移: {self.history[-1]:.3e} %", True, (200, 200, 200))
         surface.blit(text, (10, 5))
+
+    def export_csv(self, file, delimiter=","):
+        """Export the recorded energy drift history to a CSV file.
+
+        Parameters
+        ----------
+        file : str or file-like
+            Destination filename or open file object.
+        delimiter : str, optional
+            Delimiter used between columns (default is ',').
+        """
+        close = False
+        if isinstance(file, (str, bytes, os.PathLike)):
+            f = open(file, "w", newline="")
+            close = True
+        else:
+            f = file
+        writer = csv.writer(f, delimiter=delimiter)
+        writer.writerow(["step", "energy_drift_percent"])
+        for i, drift in enumerate(self.history):
+            writer.writerow([i, drift])
+        if close:
+            f.close()


### PR DESCRIPTION
## Summary
- allow exporting `EnergyMonitor` history to CSV
- document energy monitoring in README
- test CSV export behaviour

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d9690e28832791c188b078536f86