### PR TITLE
Add 4th-order symplectic integrator with GR improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ from threebody import Body, perform_rk4_step, compute_accelerations, system_ener
 `compute_accelerations` operates directly on NumPy arrays and is shared by both
 the lightweight `threebody.physics` module and the interactive simulation.  Set
 ``use_gpu=True`` to offload the force calculation with CuPy when available.
+When ``use_gr=True`` the routine applies first post‑Newtonian corrections to
+model relativistic perihelion precession.
 `perform_rk4_step` advances bodies using a Runge–Kutta 4th order integrator.
 
 The interactive application uses a richer `Body` implementation found in
@@ -111,9 +113,10 @@ Three integrators are provided:
 * **Adaptive RK4** via :py:meth:`threebody.physics_utils.adaptive_rk4_step` –
   automatically adjusts the time step to keep the estimated local error below
   ``ERROR_TOLERANCE``.
-* **Symplectic Leapfrog** – a new energy conserving integrator available from
-  ``threebody.integrators``. It is particularly suited to long term orbital
-  integrations.
+* **Symplectic Leapfrog** – a second‑order energy conserving method available
+  from ``threebody.integrators``.
+* **Fourth‑Order Symplectic** via ``symplectic4_step_arrays`` – based on the
+  Forest–Ruth scheme for long term orbital integrations.
 
 These are standard explicit methods as described in
 [Hairer et&nbsp;al.](https://doi.org/10.1007/978-3-642-05415-1) and
@@ -186,10 +189,12 @@ values include:
 
 ## Simulation Accuracy
 
-Both integrators are fourth‑order Runge–Kutta schemes which provide good
-accuracy for moderate step sizes.  Unit tests integrate the Earth–Sun system for
-30 days and verify that total energy is conserved to within 0.1%, confirming the
-stability of the default parameters.
+The default leapfrog solver is second order while ``symplectic4_step_arrays``
+and ``perform_rk4_step`` are fourth order. Unit tests integrate the Earth–Sun
+system for 30 days and verify that total energy is conserved to within 0.1%,
+confirming the stability of the default parameters. When enabled, general
+relativity corrections approximate Schwarzschild precession at the
+first post‑Newtonian order.
 
 Gravitational forces follow Newton's law with a small softening term to avoid
 singularities.  Numerical errors will grow over time, so reducing the time step

--- a/tests/test_integrators_extended.py
+++ b/tests/test_integrators_extended.py
@@ -4,6 +4,7 @@ import math
 from threebody import Body, perform_rk4_step, system_energy, G_REAL, SPACE_SCALE
 from threebody.integrators import compute_accelerations
 from threebody.physics_utils import detect_and_handle_collisions
+from threebody.integrators import symplectic4_step_arrays
 
 
 def _total_momentum(bodies):
@@ -25,6 +26,22 @@ def _symplectic_step_bodies(bodies, dt, g_constant=G_REAL):
     pos = pos + dt * vel_half / SPACE_SCALE
     acc_new = compute_accelerations(pos, masses, fixed_mask, g_constant)
     vel = vel_half + 0.5 * dt * acc_new
+
+    for b, p, v, fixed in zip(bodies, pos, vel, fixed_mask):
+        if not fixed:
+            b.pos = p
+            b.vel = v
+
+
+def _symplectic4_step_bodies(bodies, dt, g_constant=G_REAL):
+    pos = np.array([b.pos for b in bodies], dtype=float)
+    vel = np.array([b.vel for b in bodies], dtype=float)
+    masses = np.array([b.mass for b in bodies], dtype=float)
+    fixed_mask = np.array([b.fixed for b in bodies], dtype=bool)
+
+    pos, vel = symplectic4_step_arrays(
+        pos, vel, masses, fixed_mask, dt, g_constant
+    )
 
     for b, p, v, fixed in zip(bodies, pos, vel, fixed_mask):
         if not fixed:
@@ -75,6 +92,22 @@ def test_multi_year_symplectic_stability():
     assert np.allclose(p0, p1, atol=1e15)
 
 
+def test_multi_year_symplectic4_stability():
+    bodies = _init_orbit_bodies()
+    e0 = system_energy(bodies, G_REAL)[2]
+    p0 = _total_momentum(bodies)
+
+    dt = 86400.0
+    for _ in range(365 * 10):
+        _symplectic4_step_bodies(bodies, dt, G_REAL)
+
+    e1 = system_energy(bodies, G_REAL)[2]
+    p1 = _total_momentum(bodies)
+
+    assert math.isclose(e0, e1, rel_tol=1e-6)
+    assert np.allclose(p0, p1, atol=1e15)
+
+
 def _init_collision_bodies():
     from threebody import constants as C
     b1 = Body(C.EARTH_MASS, [-0.007, 0.0], [1000.0, 0.0])
@@ -107,6 +140,14 @@ def test_rk4_collision_bounce():
 def test_symplectic_collision_bounce():
     bodies = _init_collision_bodies()
     p0, p1, bodies = _run_collision_sim(bodies, _symplectic_step_bodies)
+    b1, b2 = bodies
+    assert b1.vel[0] < 0 and b2.vel[0] > 0
+    assert np.allclose(p0, p1)
+
+
+def test_symplectic4_collision_bounce():
+    bodies = _init_collision_bodies()
+    p0, p1, bodies = _run_collision_sim(bodies, _symplectic4_step_bodies)
     b1, b2 = bodies
     assert b1.vel[0] < 0 and b2.vel[0] > 0
     assert np.allclose(p0, p1)

--- a/threebody/physics_utils.py
+++ b/threebody/physics_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 from . import constants as C
-from .integrators import rk4_step_arrays, leapfrog_step_arrays
+from .integrators import rk4_step_arrays, leapfrog_step_arrays, symplectic4_step_arrays
 from .physics import Body as PhysicsBody
 from .jit import apply_boundary_conditions_jit
 
@@ -29,6 +29,17 @@ def step_simulation(
 
     if integrator_type == 'RK4':
         new_pos, new_vel = rk4_step_arrays(
+            positions,
+            velocities,
+            masses,
+            fixed_mask,
+            dt,
+            g_constant,
+            use_gr,
+            use_gpu=use_gpu,
+        )
+    elif integrator_type == 'Symplectic4':
+        new_pos, new_vel = symplectic4_step_arrays(
             positions,
             velocities,
             masses,

--- a/threebody/simulation_full.py
+++ b/threebody/simulation_full.py
@@ -40,7 +40,11 @@ def _create_bodies(preset_name: str, ephem=None, epoch=None):
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Three Body Simulation")
     parser.add_argument("--preset", default="Sun & Earth", help="Preset system")
-    parser.add_argument("--integrator", choices=["RK4", "Symplectic"], default="Symplectic")
+    parser.add_argument(
+        "--integrator",
+        choices=["RK4", "Symplectic", "Symplectic4"],
+        default="Symplectic",
+    )
     parser.add_argument("--adaptive", action="store_true", help="Use adaptive RK4")
     parser.add_argument("--use-gpu", action="store_true", help="Enable GPU acceleration")
     parser.add_argument("--gr", action="store_true", help="Use general relativity correction")


### PR DESCRIPTION
## Summary
- implement Yoshida 4th order symplectic integrator
- vectorize GR correction in `compute_accelerations`
- expose new integrator in `step_simulation` and CLI
- document the new integrator and GR option in README
- add unit tests for 4th order symplectic solver

## Testing
- `pip install -r requirements.txt`
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f227ab7883278fdca41642790412