### PR TITLE
Fix GPU acceleration compatibility

### DIFF
--- a/threebody/integrators.py
+++ b/threebody/integrators.py
@@ -36,20 +36,20 @@ def compute_accelerations(
     n = len(masses)
     if n == 0:
         # 确保返回与输入形状匹配的空数组
-        return np.zeros_like(positions, dtype=np.float64)
+        return xp.zeros_like(positions, dtype=xp.float64)
 
     # 确保位置和速度是3D的
     if positions.shape[1] == 2:
-        positions_3d = np.hstack([positions, np.zeros((n, 1), dtype=positions.dtype)])
+        positions_3d = xp.hstack([positions, xp.zeros((n, 1), dtype=positions.dtype)])
     else:
         positions_3d = positions
     
     if velocities is not None and velocities.shape[1] == 2:
-        velocities_3d = np.hstack([velocities, np.zeros((n, 1), dtype=velocities.dtype)])
+        velocities_3d = xp.hstack([velocities, xp.zeros((n, 1), dtype=velocities.dtype)])
     else:
         velocities_3d = velocities
 
-    acc = np.zeros_like(positions_3d, dtype=np.float64)
+    acc = xp.zeros_like(positions_3d, dtype=xp.float64)
     scale_sq = C.SPACE_SCALE ** 2
 
     for i in range(n):


### PR DESCRIPTION
## Summary
- ensure compute_accelerations uses the correct array module for GPU mode

## Testing
- `pip install numpy numba pygame-ce pygame_gui jplephem matplotlib`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f465ed3c83278a4a3f19a35fcd35