### PR TITLE
Fix gravity units and GPU acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,12 @@ distances become millions of times larger than intended.  The same scale is used
 internally for presets so that real solar system parameters remain numerically
 stable.
 
-Alternatively, call :py:meth:`Body.from_meters` to create a body using SI
-coordinates directly. The helper converts the position for you so the resulting
-objects interact as expected.  This is important because the gravitational
-constant ``G_REAL`` bundled with the library is expressed in SI units.
-Its value of ``6.67430e-11`` m³ kg⁻¹ s⁻² is defined in
-``threebody.constants`` and used for all gravitational calculations.
+Always use :py:meth:`Body.from_meters` when your input coordinates are in
+SI metres. The helper converts the position for you so the resulting objects
+interact as expected.  This is important because the gravitational
+constant ``G_REAL`` bundled with the library is expressed in SI units. Its
+value of ``6.67430e-11`` m³ kg⁻¹ s⁻² is defined in ``threebody.constants`` and
+used for all gravitational calculations.
 
 ## Adjusting Body Trails
 

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -1,7 +1,8 @@
-import numpy as np
 from threebody import constants as C
 from threebody.rendering import Body
 from threebody.physics_utils import detect_and_handle_collisions
+import numpy as np
+import pytest
 
 
 def test_set_trail_length_clamps():
@@ -30,6 +31,7 @@ def test_collision_bounce_when_merge_false():
     assert np.isclose(b1.vel[0], -0.7)
     assert np.isclose(b2.vel[0], 0.7)
 
+
 def test_collision_bounce_conserves_momentum():
     b1 = Body(C.EARTH_MASS, [-0.0005, 0, 0], [1.0, 0.0, 0.0], C.WHITE, 5, name="A")
     b2 = Body(C.EARTH_MASS, [0.0005, 0, 0], [-1.0, 0.0, 0.0], C.WHITE, 5, name="B")
@@ -52,3 +54,7 @@ def test_collision_merge_conserves_momentum():
     assert np.allclose(p_before, p_after)
     assert np.isclose(bodies[0].mass, 2 * C.EARTH_MASS)
 
+
+def test_init_warns_for_meter_units():
+    with pytest.warns(UserWarning):
+        Body(C.EARTH_MASS, [C.AU, 0, 0], [0, 0, 0], C.WHITE, 5)

--- a/tests/test_gpu_fallback.py
+++ b/tests/test_gpu_fallback.py
@@ -24,3 +24,45 @@ def test_gpu_fallback(monkeypatch):
     acc_cpu = compute_accelerations(pos, masses, fixed_mask)
 
     assert np.allclose(acc_gpu, acc_cpu)
+
+
+def test_gpu_path_uses_xp(monkeypatch):
+    import types
+
+    fake_cp = types.SimpleNamespace()
+    fake_cp.asarray = np.asarray
+    fake_cp.asnumpy = np.asarray
+    fake_cp.einsum = np.einsum
+    fake_cp.sqrt = np.sqrt
+    fake_cp.cross = np.cross
+    fake_cp.sum = np.sum
+    fake_cp.isfinite = np.isfinite
+    fake_cp.errstate = np.errstate
+    fake_cp.zeros = np.zeros
+    fake_cp.zeros_like = np.zeros_like
+    fake_cp.hstack = np.hstack
+    fake_cp.inf = np.inf
+    fake_cp.float64 = np.float64
+    fake_cp.newaxis = np.newaxis
+
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "cupy":
+            return fake_cp
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setitem(sys.modules, "cupy", fake_cp)
+
+    def boom(*args, **kwargs):
+        raise AssertionError("numpy fallback used")
+
+    monkeypatch.setattr(np, "hstack", boom)
+    monkeypatch.setattr(np, "zeros_like", boom)
+
+    pos = np.array([[0.0, 0.0], [1.0, 0.0]], dtype=float)
+    masses = np.array([1.0, 1.0], dtype=float)
+    fixed_mask = np.array([False, False])
+
+    compute_accelerations(pos, masses, fixed_mask, use_gpu=True)

--- a/threebody/integrators.py
+++ b/threebody/integrators.py
@@ -36,20 +36,26 @@ def compute_accelerations(
     n = len(masses)
     if n == 0:
         # 确保返回与输入形状匹配的空数组
-        return np.zeros_like(positions, dtype=np.float64)
+        return xp.zeros_like(positions, dtype=float)
 
     # 确保位置和速度是3D的
     if positions.shape[1] == 2:
-        positions_3d = np.hstack([positions, np.zeros((n, 1), dtype=positions.dtype)])
+        positions_3d = xp.hstack([
+            positions,
+            xp.zeros((n, 1), dtype=positions.dtype),
+        ])
     else:
         positions_3d = positions
-    
+
     if velocities is not None and velocities.shape[1] == 2:
-        velocities_3d = np.hstack([velocities, np.zeros((n, 1), dtype=velocities.dtype)])
+        velocities_3d = xp.hstack([
+            velocities,
+            xp.zeros((n, 1), dtype=velocities.dtype),
+        ])
     else:
         velocities_3d = velocities
 
-    acc = np.zeros_like(positions_3d, dtype=np.float64)
+    acc = xp.zeros_like(positions_3d, dtype=float)
     scale_sq = C.SPACE_SCALE ** 2
 
     for i in range(n):

--- a/threebody/rendering.py
+++ b/threebody/rendering.py
@@ -4,6 +4,7 @@
 简单的物理天体，增加了颜色、半径和轨迹管理等额外的视觉属性。
 """
 from collections import deque
+import warnings
 import pygame
 import pygame.gfxdraw
 import numpy as np
@@ -27,6 +28,12 @@ class Body:
         p = np.asarray(pos, dtype=float).reshape(-1)
         if p.size < 3:
             p = np.pad(p, (0, 3 - p.size))
+        if np.any(np.abs(p) > C.SPACE_SCALE):
+            warnings.warn(
+                "Position values appear to be in metres. "
+                "Use Body.from_meters() to convert to simulation units.",
+                UserWarning,
+            )
         self.pos = p[:3] # 内部存储的是模拟单位
 
         v = np.asarray(vel, dtype=float).reshape(-1)


### PR DESCRIPTION
## Summary
- warn when Body positions look unscaled so users use `from_meters`
- rely on xp functions in GPU path for accelerations
- document required use of `Body.from_meters`
- test warning trigger
- test that GPU code avoids numpy when cupy is available

## Testing
- `flake8 threebody tests | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f45d1d8883278b491dcf9fd855b9