### PR TITLE
Fix camera defaults and share UI manager

### DIFF
--- a/threebody/camera.py
+++ b/threebody/camera.py
@@ -6,21 +6,23 @@ from .physics_utils import calculate_center_of_mass
 class Camera:
     """Manage view transformation and focus handling."""
 
-    def __init__(self, zoom=C.ZOOM_BASE, pan_offset=None):
-        self.zoom = float(zoom)
-        self.pan_offset = (
-            np.array(pan_offset, dtype=float) if pan_offset is not None else C.INITIAL_PAN_OFFSET.astype(float).copy()
-        )
+    def __init__(self):
+        """Initialize camera with sensible defaults."""
+        self.zoom = C.ZOOM_BASE
+        sim_width = C.WIDTH - C.UI_SIDEBAR_WIDTH
+        sim_height = C.HEIGHT - C.UI_BOTTOM_HEIGHT
+        self.pan_offset = np.array([sim_width / 2, sim_height / 2], dtype=float)
 
     def world_to_screen(self, pos):
         """Convert a world position to screen coordinates."""
         pos = np.asarray(pos, dtype=float)
         return pos[:2] * self.zoom + self.pan_offset
 
-    def update_focus(self, focus_body, bodies, screen_center):
+    def update_focus(self, focus_body, bodies):
         """Smoothly update the camera pan to follow the focus target."""
         if focus_body is None:
             return
+
         if focus_body == "COM":
             com_pos, _ = calculate_center_of_mass(bodies)
             if com_pos is None:
@@ -29,5 +31,9 @@ class Camera:
         else:
             target_pos = focus_body.pos[:2]
 
+        screen_center = np.array(
+            [C.WIDTH - C.UI_SIDEBAR_WIDTH, C.HEIGHT - C.UI_BOTTOM_HEIGHT],
+            dtype=float,
+        ) / 2
         target = screen_center - target_pos * self.zoom
         self.pan_offset += (target - self.pan_offset) * C.CAMERA_SMOOTHING

--- a/threebody/simulation_full.py
+++ b/threebody/simulation_full.py
@@ -71,10 +71,11 @@ def main(argv=None):
     theme_path = Path(__file__).with_name("theme.json")
     manager = pygame_gui.UIManager((C.WIDTH, C.HEIGHT), theme_path) # From codex branch (for GUI)
     control = ControlPanel(manager, args.preset)                   # From codex branch (for UI widgets)
-    ui = UIManager(                                                # From main branch (for simulation state)
+    ui = UIManager(
+        manager,
         integrator=args.integrator,
         adaptive=args.adaptive,
-        use_gr=args.use_gr,
+        use_gr=args.gr,
         show_field=args.show_field,
     )
     camera = Camera()                                              # From main branch (for camera control)

--- a/threebody/ui_manager.py
+++ b/threebody/ui_manager.py
@@ -1,6 +1,5 @@
 import pygame
 import pygame_gui
-from pathlib import Path
 
 from . import constants as C
 from .presets import PRESETS
@@ -133,18 +132,13 @@ class UIManager:
 
     def __init__(
         self,
+        manager: pygame_gui.UIManager,
         integrator="Symplectic",
         adaptive=False,
         use_gr=False,
         show_field=False,
-        *,
-        theme_path=None,
     ):
-        if theme_path is None:
-            theme_path = Path(__file__).with_name("theme.json")
-        # NOTE: This creates a second UIManager. This should be refactored later
-        # to share the one created in simulation_full.py. For now, this resolves the conflict.
-        self.manager = pygame_gui.UIManager((C.WIDTH, C.HEIGHT), theme_path)
+        self.manager = manager
 
         panel = pygame_gui.elements.UIPanel(
             pygame.Rect(


### PR DESCRIPTION
## Summary
- ensure Camera starts centered and computes screen center internally
- let UIManager accept the main `pygame_gui.UIManager` instead of creating a second one
- update simulation to pass the shared manager
- fix CLI argument reference for GR flag

## Testing
- `pytest -q` *(fails: tests/test_momentum_property.py::test_total_momentum_conserved)*

------
https://chatgpt.com/codex/tasks/task_e_6846124a72148327a9230678677d1751