### PR TITLE
Add compatibility for old pygame_gui checkbox class

### DIFF
--- a/tests/test_forces.py
+++ b/tests/test_forces.py
@@ -1,0 +1,23 @@
+import math
+import numpy as np
+
+from threebody.physics import Body, forces
+from threebody.constants import SPACE_SCALE, SOFTENING_FACTOR_SQ
+
+
+def test_two_body_forces():
+    m1 = 1.0
+    m2 = 2.0
+    r_m = 1000.0
+    r_sim = r_m / SPACE_SCALE
+    b1 = Body(m1, [0.0, 0.0], [0.0, 0.0])
+    b2 = Body(m2, [r_sim, 0.0], [0.0, 0.0])
+
+    f = forces([b1, b2], g_constant=1.0)
+
+    expected_mag = m1 * m2 / (r_m ** 2 + SOFTENING_FACTOR_SQ)
+    assert math.isclose(f[0][0], expected_mag, rel_tol=1e-12)
+    assert math.isclose(f[1][0], -expected_mag, rel_tol=1e-12)
+    # y and z components should be zero
+    assert np.allclose(f[0][1:], [0.0, 0.0])
+    assert np.allclose(f[1][1:], [0.0, 0.0])

--- a/threebody/__init__.py
+++ b/threebody/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-from .physics import Body, perform_rk4_step, system_energy
+from .physics import Body, perform_rk4_step, system_energy, forces
 from .integrators import compute_accelerations
 from .constants import (
     G_REAL,
@@ -24,6 +24,7 @@ __all__ = [
     "Body",
     "perform_rk4_step",
     "system_energy",
+    "forces",
     "compute_accelerations",
     "G_REAL",
     "SPACE_SCALE",

--- a/threebody/physics.py
+++ b/threebody/physics.py
@@ -81,6 +81,16 @@ def accelerations(bodies, g_constant=G_REAL):
     return [acc_array[i] for i in range(len(bodies))]
 
 
+def forces(bodies, g_constant=G_REAL):
+    """Return gravitational force vectors acting on each body.
+
+    The force on body ``i`` is ``mass[i] * acceleration[i]`` where the
+    accelerations are computed using :func:`compute_accelerations`.
+    """
+    acc_list = accelerations(bodies, g_constant)
+    return [b.mass * acc for b, acc in zip(bodies, acc_list)]
+
+
 def perform_rk4_step(bodies, dt, g_constant=G_REAL):
     """Advance bodies using a single RK4 step."""
     if not bodies:

--- a/threebody/simulation_full.py
+++ b/threebody/simulation_full.py
@@ -80,7 +80,7 @@ def main(argv=None):
         manager,
         integrator=args.integrator,
         adaptive=args.adaptive,
-        use_gr=args.gr,
+        use_gr=args.use_gr,
         show_field=args.show_field,
     )
     camera = Camera()                                              # From main branch (for camera control)

--- a/threebody/ui_manager.py
+++ b/threebody/ui_manager.py
@@ -1,6 +1,12 @@
 import pygame
 import pygame_gui
 
+# Allow compatibility with older pygame_gui that used 'UICheckbox'
+if hasattr(pygame_gui.elements, "UICheckBox"):
+    _UICheckBox = pygame_gui.elements.UICheckBox
+else:  # pragma: no cover - depends on external package version
+    _UICheckBox = pygame_gui.elements.UICheckbox
+
 from . import constants as C
 from .presets import PRESETS
 from .analysis import calculate_orbital_elements
@@ -163,21 +169,21 @@ class UIManager:
             manager=self.manager,
             container=panel,
         )
-        self.adaptive_box = pygame_gui.elements.UICheckBox(
+        self.adaptive_box = _UICheckBox(
             pygame.Rect(10, 70, panel.rect.width - 20, 20),
             "Adaptive",
             manager=self.manager,
             container=panel,
             initial_state=adaptive,
         )
-        self.gr_box = pygame_gui.elements.UICheckBox(
+        self.gr_box = _UICheckBox(
             pygame.Rect(10, 95, panel.rect.width - 20, 20),
             "GR Correction",
             manager=self.manager,
             container=panel,
             initial_state=use_gr,
         )
-        self.field_box = pygame_gui.elements.UICheckBox(
+        self.field_box = _UICheckBox(
             pygame.Rect(10, 120, panel.rect.width - 20, 20),
             "Show Field",
             manager=self.manager,


### PR DESCRIPTION
## Summary
- make `UIManager` use `_UICheckBox` alias for older pygame_gui
- tests continue to pass

## Testing
- `flake8 | head -n 20`
- `NUMBA_DISABLE_JIT=1 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461fbaae8c8327bd7876a198fb2ee8