### PR TITLE
Fix GR command line flag name

### DIFF
--- a/threebody/simulation_full.py
+++ b/threebody/simulation_full.py
@@ -56,7 +56,6 @@ def main(argv=None):
     parser.add_argument("--use-gpu", action="store_true", help="Enable GPU acceleration")
     parser.add_argument(
         "--gr",
-        dest="use_gr",
         action="store_true",
         help="Use general relativity correction",
     )


### PR DESCRIPTION
## Summary
- remove incorrect `dest` parameter for `--gr` option so `args.gr` exists

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'threebody')*

------
https://chatgpt.com/codex/tasks/task_e_68461ef1d9c083278b2bf7b7d4d6f7f2