### PR TITLE
Fix pygame_gui compatibility

### DIFF
--- a/tests/test_ui_manager_import.py
+++ b/tests/test_ui_manager_import.py
@@ -1,0 +1,18 @@
+import importlib
+import types
+import sys
+
+import pygame_gui
+
+
+def test_uicheckbox_import_fallback(monkeypatch):
+    # create fake elements module without checkbox attributes
+    fake_elements = types.SimpleNamespace(ui_check_box=pygame_gui.elements.ui_check_box)
+    monkeypatch.setattr(pygame_gui, "elements", fake_elements)
+    monkeypatch.setitem(sys.modules, "pygame_gui.elements", fake_elements)
+
+    import threebody.ui_manager as ui_manager
+    importlib.reload(ui_manager)
+
+    assert ui_manager._UICheckBox is pygame_gui.elements.ui_check_box.UICheckBox
+

--- a/threebody/simulation_full.py
+++ b/threebody/simulation_full.py
@@ -79,7 +79,7 @@ def main(argv=None):
         manager,
         integrator=args.integrator,
         adaptive=args.adaptive,
-        use_gr=args.use_gr,
+        use_gr=args.gr,
         show_field=args.show_field,
     )
     camera = Camera()                                              # From main branch (for camera control)

--- a/threebody/ui_manager.py
+++ b/threebody/ui_manager.py
@@ -7,7 +7,15 @@ if hasattr(pygame_gui.elements, "UICheckBox"):
 elif hasattr(pygame_gui.elements, "UICheckbox"):  # pragma: no cover - older versions
     _UICheckBox = pygame_gui.elements.UICheckbox
 else:  # pragma: no cover - unexpected version
-    raise ImportError("UICheckBox class not found in pygame_gui.elements")
+    try:
+        from pygame_gui.elements.ui_check_box import UICheckBox as _UICheckBox
+    except Exception:  # pragma: no cover - fallback also failed
+        try:
+            from pygame_gui.elements.ui_check_box import UICheckbox as _UICheckBox
+        except Exception as exc:
+            raise ImportError(
+                "UICheckBox class not found in pygame_gui.elements"
+            ) from exc
 
 from . import constants as C
 from .presets import PRESETS


### PR DESCRIPTION
## Summary
- fix `UICheckBox` import logic for older pygame_gui versions
- correct `--gr` argument usage
- test fallback import logic

## Testing
- `pytest -q`
- `ruff check .` *(fails: unused imports and style issues)*
- `flake8` *(fails: style violations)*

------
https://chatgpt.com/codex/tasks/task_e_6846ca0cdce8832799f1d1f5833c0e61