### PR TITLE
Fix pygame_gui compatibility

### DIFF
--- a/tests/test_ui_manager_import.py
+++ b/tests/test_ui_manager_import.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+import types
+
+import pygame_gui
+
+
+def test_uicheckbox_import_fallback(monkeypatch):
+    """Ensure UICheckBox can be imported from a submodule."""
+    fake_module = types.ModuleType("pygame_gui.elements.ui_check_box")
+
+    class DummyCheckBox:  # noqa: D401 - simple dummy class
+        """Dummy checkbox class."""
+
+    fake_module.UICheckBox = DummyCheckBox
+    fake_elements = types.SimpleNamespace(ui_check_box=fake_module)
+    monkeypatch.setattr(pygame_gui, "elements", fake_elements)
+    monkeypatch.setitem(sys.modules, "pygame_gui.elements", fake_elements)
+    monkeypatch.setitem(
+        sys.modules,
+        "pygame_gui.elements.ui_check_box",
+        fake_module,
+    )
+
+    import threebody.ui_manager as ui_manager
+    importlib.reload(ui_manager)
+
+    assert ui_manager._UICheckBox is DummyCheckBox

--- a/threebody/simulation_full.py
+++ b/threebody/simulation_full.py
@@ -79,7 +79,7 @@ def main(argv=None):
         manager,
         integrator=args.integrator,
         adaptive=args.adaptive,
-        use_gr=args.use_gr,
+        use_gr=args.gr,
         show_field=args.show_field,
     )
     camera = Camera()                                              # From main branch (for camera control)

--- a/threebody/ui_manager.py
+++ b/threebody/ui_manager.py
@@ -1,3 +1,4 @@
+import importlib
 import pygame
 import pygame_gui
 
@@ -7,7 +8,16 @@ if hasattr(pygame_gui.elements, "UICheckBox"):
 elif hasattr(pygame_gui.elements, "UICheckbox"):  # pragma: no cover - older versions
     _UICheckBox = pygame_gui.elements.UICheckbox
 else:  # pragma: no cover - unexpected version
-    raise ImportError("UICheckBox class not found in pygame_gui.elements")
+    try:
+        mod = importlib.import_module("pygame_gui.elements.ui_check_box")
+        if hasattr(mod, "UICheckBox"):
+            _UICheckBox = mod.UICheckBox
+        else:  # pragma: no cover - older versions
+            _UICheckBox = mod.UICheckbox
+    except (ImportError, AttributeError) as exc:  # pragma: no cover - fallback failed
+        raise ImportError(
+            "UICheckBox class not found in pygame_gui.elements"
+        ) from exc
 
 from . import constants as C
 from .presets import PRESETS


### PR DESCRIPTION
## Summary
- fix `UICheckBox` import logic for older pygame_gui versions
- add test for submodule fallback logic

## Testing
- `pytest -q`
- `ruff check .` *(fails: unused imports and style issues)*
- `flake8` *(fails: style violations)*

------
https://chatgpt.com/codex/tasks/task_e_6846ca0cdce8832799f1d1f5833c0e61